### PR TITLE
Remove non working disabled logic

### DIFF
--- a/projects/ngx-loading-buttons/src/lib/mat-basic-spinner.directive.ts
+++ b/projects/ngx-loading-buttons/src/lib/mat-basic-spinner.directive.ts
@@ -15,10 +15,4 @@ export class MatBasicSpinnerDirective {
 
   @HostBinding('class.hide-btn-text')
   textHidden = false
-
-  @HostBinding('disabled')
-  get disabled(): boolean {
-    return this.mtBasicSpinner;
-  }
-
 }


### PR DESCRIPTION
I've removed the method, since it will not work.

The reason is that if a user wish to set `[disabled]` directly in the button & add the spinner, as soon as the spinner is triggered, then it will change the disabled logic.

I've searched a way of fixing it, but it doesn't makes sense. 

The user should add himself a logic that avoid sending new data if clicked multiple time on the button.

The other reason why it isn't optimal, is that loading will then change to gray, since it's now disabled.   What we may not wish