### PR TITLE
add - css : fadout capability

### DIFF
--- a/projects/ngx-loading-buttons/src/styles.css
+++ b/projects/ngx-loading-buttons/src/styles.css
@@ -6,6 +6,11 @@
     to {transform: rotate(360deg);}
 }
 
+.mat-spinner .mdc-button__label {
+  transition: opacity 0.3s ease-in-out;
+  opacity: var(--spinner-opacity, 0.2);
+}
+
 .mat-spinner::after {
     content: '';
     box-sizing: border-box;


### PR DESCRIPTION
This change is meant to replace the `hide-btn-text `logic. 

With this method, we can choose how much the text have to fade out, with a default of 0.2.

Once this merge get accepted, we can safely remove the `hide-btn-text` and his related `@Input()` logic. Wish will make the directive even lighter.