### PR TITLE
Export style from lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ And our template file.
 <button mat-raised-button [mtBasicSpinner]="saving" (click)="save()">Basic</button>
 ```
 
+Add our styles to yours
+
+```scss
+@import 'ngx-loading-buttons/styles';
+```
+
 ## Issues 🐛
 
 Found a bug? Want to request a feature? Confused? Or wanna simply comment on how useful this library is? 

--- a/projects/ngx-loading-buttons/package.json
+++ b/projects/ngx-loading-buttons/package.json
@@ -21,5 +21,12 @@
   "license": "MIT",
   "repository": {
     "url": "https://github.com/dkreider/ngx-loading-buttons"
+  },
+  "files": [
+    "styles.css"
+  ],
+  "exports": {
+    "./styles": "./styles.css",
+    "./styles.css": "./styles.css"
   }
 }

--- a/projects/ngx-loading-buttons/styles.css
+++ b/projects/ngx-loading-buttons/styles.css
@@ -1,0 +1,1 @@
+@import "./src/styles.css";


### PR DESCRIPTION
This pr helps users importing you style directly in a scss without point to a single file in node module. 
I added two ways for the people

example 1

@import 'ngx-loading-buttons/styles';

example 2

@import 'ngx-loading-buttons/styles.css';

I updated the readme as well. 
For testing you could copy dist to node modules because the setting in the ts config is not working here.
