### PR TITLE
fix: include all files in the pack, that is published

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: latest
+          node-version: lts/*
 
       - name: Install dependencies
         # If checksum for the `package-lock.json` hasn't changed then we shouldn't run

--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -1,7 +1,7 @@
 name: NPM Publish
 
 env:
-  NODE_VERSION: latest
+  NODE_VERSION: lts/*
 
 on:
   release:

--- a/projects/ngx-loading-buttons/package.json
+++ b/projects/ngx-loading-buttons/package.json
@@ -22,9 +22,6 @@
   "repository": {
     "url": "https://github.com/dkreider/ngx-loading-buttons"
   },
-  "files": [
-    "styles.css"
-  ],
   "exports": {
     "./styles": "./styles.css",
     "./styles.css": "./styles.css"

--- a/projects/ngx-loading-buttons/package.json
+++ b/projects/ngx-loading-buttons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-loading-buttons",
-  "version": "18.0.0",
+  "version": "18.0.1",
   "peerDependencies": {
     "@angular/common": "^18.0.0",
     "@angular/core": "^18.0.0",

--- a/projects/ngx-loading-buttons/package.json
+++ b/projects/ngx-loading-buttons/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/dkreider/ngx-loading-buttons"
   },
   "exports": {
-    "./styles": "./styles.css",
-    "./styles.css": "./styles.css"
+    "./styles": "./src/styles.css",
+    "./styles.css": "./src/styles.css"
   }
 }


### PR DESCRIPTION
Fixes #28 

The current package on npm is a stub and only has two files: [here](https://www.npmjs.com/package/ngx-loading-buttons/v/18.0.0?activeTab=code) 
![image](https://github.com/user-attachments/assets/017bc2fb-7d31-4a70-a0b2-1f17217cd3a7)


This was introduced in [#25](https://github.com/dkreider/ngx-loading-buttons/pull/25/files#diff-708c814a16b42acbedfccb1323d960414d93868323f003b02f3c9c6bd191240cR25-R27)


To see this error run `npm run build:ngx-loading-buttons && npm pack dist/ngx-loading-buttons/` before and after this PR.

You can see before this, it only packs two files, after this it packs all necessary files.

Another error from #25 is, that there is no file `./styles.css` in the dist folder, only one in `./src/styles.css`.

I wonder how #25 got merged 😓 😂  Feel free to test this extensively and in a real world scenario, than you can see that this works, and the previous state not 😓 

